### PR TITLE
Fix draft update flow,recent submissions routing,stale draft content in writing editor

### DIFF
--- a/frontend/src/features/dashboard/components/RecentSubmissionsCard.jsx
+++ b/frontend/src/features/dashboard/components/RecentSubmissionsCard.jsx
@@ -1,6 +1,12 @@
 import { MessageCircle } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
+const statusBgColor = {
+  draft: 'bg-yellow-100',
+  submitted: 'bg-blue-100',
+  corrected: 'bg-green-100',
+};
+
 export default function RecentSubmissionsCard({ submissions = [] }) {
   return (
     <div
@@ -55,6 +61,12 @@ export default function RecentSubmissionsCard({ submissions = [] }) {
                   <div className='flex items-start justify-between mb-3'>
                     <span className='text-[10px] lg:text-[11px] font-bold text-[#5D45FD] bg-[#E8EDFF] px-2.5 py-1 rounded-full uppercase tracking-wider shrink-0'>
                       {item.language}
+                    </span>
+
+                    <span
+                      className={`text-[10px] lg:text-[11px] font-bold text-[#5D45FD] ${statusBgColor[item.status]}  px-2.5 py-1 rounded-full uppercase tracking-wider shrink-0`}
+                    >
+                      {item.status}
                     </span>
 
                     {item.comments > 0 && (

--- a/frontend/src/features/dashboard/components/RecentSubmissionsCard.jsx
+++ b/frontend/src/features/dashboard/components/RecentSubmissionsCard.jsx
@@ -35,52 +35,56 @@ export default function RecentSubmissionsCard({ submissions = [] }) {
             <p className='text-sm text-gray-500'>No submissions yet.</p>
           </div>
         ) : (
-          submissions.map((item) => (
-            <Link
-              to={`/submissions/${item.id}`}
-              key={item.id}
-              className='block'
-            >
-              <div
-                className='
-                group relative bg-white border border-gray-100 
-                hover:border-indigo-100 hover:shadow-md transition-all duration-300 cursor-pointer
-                lg:p-6 lg:rounded-[28px]
-                p-5 rounded-[2.5rem]
-              '
-              >
-                <div className='flex items-start justify-between mb-3'>
-                  <span className='text-[10px] lg:text-[11px] font-bold text-[#5D45FD] bg-[#E8EDFF] px-2.5 py-1 rounded-full uppercase tracking-wider shrink-0'>
-                    {item.language}
-                  </span>
+          submissions.map((item) => {
+            const id = item.id;
+            const route =
+              item.status === 'draft'
+                ? `/write/${item.id}`
+                : `/submissions/${item.id}`;
 
-                  {item.comments > 0 && (
-                    <div className='flex items-center gap-1.5 bg-[#FFF9E6] text-[#D97706] px-2.5 py-1 rounded-full border border-[#FEF3C7] shrink-0'>
-                      <MessageCircle
-                        size={13}
-                        fill='currentColor'
-                        className='opacity-80'
-                      />
-                      <span className='text-[10px] lg:text-[11px] font-bold whitespace-nowrap'>
-                        {item.comments}{' '}
-                        {item.comments === 1 ? 'review' : 'reviews'}
-                      </span>
-                    </div>
-                  )}
+            return (
+              <Link to={route} key={id} className='block'>
+                <div
+                  className='
+                  group relative bg-white border border-gray-100 
+                  hover:border-indigo-100 hover:shadow-md transition-all duration-300 cursor-pointer
+                  lg:p-6 lg:rounded-[28px]
+                  p-5 rounded-[2.5rem]
+                '
+                >
+                  <div className='flex items-start justify-between mb-3'>
+                    <span className='text-[10px] lg:text-[11px] font-bold text-[#5D45FD] bg-[#E8EDFF] px-2.5 py-1 rounded-full uppercase tracking-wider shrink-0'>
+                      {item.language}
+                    </span>
+
+                    {item.comments > 0 && (
+                      <div className='flex items-center gap-1.5 bg-[#FFF9E6] text-[#D97706] px-2.5 py-1 rounded-full border border-[#FEF3C7] shrink-0'>
+                        <MessageCircle
+                          size={13}
+                          fill='currentColor'
+                          className='opacity-80'
+                        />
+                        <span className='text-[10px] lg:text-[11px] font-bold whitespace-nowrap'>
+                          {item.comments}{' '}
+                          {item.comments === 1 ? 'review' : 'reviews'}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className='space-y-1 min-w-0'>
+                    <h3 className='text-[16px] lg:text-lg font-bold text-gray-900 group-hover:text-[#5D45FD] transition-colors leading-tight truncate'>
+                      {item.title}
+                    </h3>
+
+                    <p className='text-[13px] lg:text-sm text-gray-500 truncate whitespace-nowrap'>
+                      {item.preview}
+                    </p>
+                  </div>
                 </div>
-
-                <div className='space-y-1 min-w-0'>
-                  <h3 className='text-[16px] lg:text-lg font-bold text-gray-900 group-hover:text-[#5D45FD] transition-colors leading-tight truncate'>
-                    {item.title}
-                  </h3>
-
-                  <p className='text-[13px] lg:text-sm text-gray-500 truncate whitespace-nowrap'>
-                    {item.preview}
-                  </p>
-                </div>
-              </div>
-            </Link>
-          ))
+              </Link>
+            );
+          })
         )}
       </div>
     </div>

--- a/frontend/src/features/dashboard/pages/Dashboard.jsx
+++ b/frontend/src/features/dashboard/pages/Dashboard.jsx
@@ -16,22 +16,31 @@ export default function Dashboard() {
   const dispatch = useDispatch();
 
   // Get general dashboard data
-  const { user, prompts, recentPosts, loading: dashLoading, error } =
-    useSelector((state) => state.dashboard);
+  const {
+    user,
+    prompts,
+    recentPosts,
+    loading: dashLoading,
+    error,
+  } = useSelector((state) => state.dashboard);
 
   // Get your personal correction history from the new slice
-  const { myCorrections, loading: corrLoading } = useSelector((state) => state.corrections);
+  const { myCorrections, loading: corrLoading } = useSelector(
+    (state) => state.corrections,
+  );
 
   useEffect(() => {
     dispatch(fetchDashboardData());
     // UPDATE: Fetch 'all' to show a mix of contributions and feedback on the dashboard
-    dispatch(fetchMyCorrections('all')); 
+    dispatch(fetchMyCorrections('all'));
   }, [dispatch]);
 
   const isLoading = dashLoading || corrLoading;
 
   if (isLoading && !user) {
-    return <p className='p-8 text-gray-500 font-medium'>Loading your workspace...</p>;
+    return (
+      <p className='p-8 text-gray-500 font-medium'>Loading your workspace...</p>
+    );
   }
 
   if (error) {
@@ -64,13 +73,15 @@ export default function Dashboard() {
         preview: post.preview,
         comments: post.corrections_count || 0,
         createdAt: post.created_at,
+        status: post.status,
       };
     }) || [];
+
+  // console.log(formattedSubmissions);
 
   return (
     <div className='min-h-screen bg-[#F8FAFF] px-1 py-4 md:p-8 pb-5 md:pb-8'>
       <div className='container mx-auto grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8'>
-        
         {/* Sidebar */}
         <aside className='lg:col-span-4 order-1'>
           <JourneyCard languages={learningLanguages} />
@@ -81,9 +92,9 @@ export default function Dashboard() {
           <PromptCard prompt={firstPrompt} />
 
           {/* RecentActivityCard now receives the 'all' mixed feed */}
-          <RecentActivityCard 
-            activities={myCorrections} 
-            isLoading={corrLoading} 
+          <RecentActivityCard
+            activities={myCorrections}
+            isLoading={corrLoading}
           />
 
           <RecentSubmissionsCard submissions={formattedSubmissions} />

--- a/frontend/src/features/write/components/WritingEditor.jsx
+++ b/frontend/src/features/write/components/WritingEditor.jsx
@@ -69,19 +69,23 @@ export default function WritingEditor({ prompt }) {
       setPendingStatus(null);
       dispatch(clearCurrentDraft());
     }
-  }, [submitSuccess, dispatch, pendingStatus]);
+  }, [submitSuccess, dispatch, pendingStatus, navigate]);
 
   // Handle update success
   useEffect(() => {
     if (updateSuccess) {
-      toast.success(
-        pendingStatus === 'draft' ? 'Draft saved!' : 'Reflection published!',
-      );
+      const isDraft = pendingStatus === 'draft';
+      toast.success(isDraft ? 'Draft saved!' : 'Reflection published!');
+
+      if (!isDraft) {
+        navigate('/submissions');
+      }
+
       setContent('');
       setPendingStatus(null);
       dispatch(clearCurrentDraft());
     }
-  }, [updateSuccess, dispatch, pendingStatus]);
+  }, [updateSuccess, dispatch, pendingStatus, navigate]);
 
   const buildPostData = (status) => ({
     prompt_id: prompt?.id,
@@ -112,15 +116,21 @@ export default function WritingEditor({ prompt }) {
 
   const handleSaveDraft = () => {
     if (!prompt || !content.trim() || isOverLimit) return;
+
+    const postData = buildPostData('draft');
+    const existingDraftId = draftId;
+
     setPendingStatus('draft');
-    if (isEditingDraft) {
-      dispatch(
-        updatePost({ postId: draftId, postData: buildPostData('draft') }),
-      );
+
+    if (existingDraftId) {
+      dispatch(updatePost({ postId: draftId, postData }));
     } else {
       dispatch(createPost(buildPostData('draft')));
     }
   };
+
+  console.log('isEditingDraft:', isEditingDraft);
+  console.log('draftId:', draftId);
 
   return (
     <form onSubmit={handleSubmit}>

--- a/frontend/src/features/write/components/WritingEditor.jsx
+++ b/frontend/src/features/write/components/WritingEditor.jsx
@@ -40,10 +40,8 @@ export default function WritingEditor({ prompt }) {
   };
 
   useEffect(() => {
-    if (currentDraft?.content !== undefined) {
-      setContent(currentDraft.content);
-    }
-  }, [currentDraft?.id, currentDraft?.content]);
+    setContent(currentDraft?.content || '');
+  }, [currentDraft]);
 
   const wordCount = useMemo(() => {
     if (!content.trim()) return 0;
@@ -129,8 +127,8 @@ export default function WritingEditor({ prompt }) {
     }
   };
 
-  console.log('isEditingDraft:', isEditingDraft);
-  console.log('draftId:', draftId);
+  // console.log('isEditingDraft:', isEditingDraft);
+  // console.log('draftId:', draftId);
 
   return (
     <form onSubmit={handleSubmit}>

--- a/frontend/src/features/write/pages/Write.jsx
+++ b/frontend/src/features/write/pages/Write.jsx
@@ -87,13 +87,15 @@ export default function Write() {
   useEffect(() => {
     if (!id) return;
 
-    getSubmissionById(id)
-      .then((fullDraft) => {
+    const fetchDraft = async () => {
+      try {
+        const fullDraft = await getSubmissionById(id);
         dispatch(setCurrentDraft(fullDraft));
-      })
-      .catch(() => {
+      } catch {
         navigate('/submissions', { replace: true });
-      });
+      }
+    };
+    fetchDraft();
   }, [id, dispatch, navigate]);
 
   useEffect(() => {


### PR DESCRIPTION
bugs:
Drafts create duplicate posts when saved multiple times
Drafts on Recent Submissions Card navigate to /submissions/:id
Publishing a draft now redirects users to the submissions page
Text Area had stale content when navigating from /write/:id to /write

Updated recent submissions cards to route drafts to /write/:id
Fixed duplicate draft creation by updating existing drafts instead of creating new posts
Added conditional routing for draft vs submitted posts
Added navigation to submissions page after publishing a draft
Included status in formatted response data for frontend draft handling
Removed conditional check preventing textarea state from resetting -> previous effect only updated when `currentDraft.content` existed