### PR TITLE
Refactor/corrections queue

### DIFF
--- a/backend/controllers/post.controller.js
+++ b/backend/controllers/post.controller.js
@@ -179,7 +179,6 @@ export const createPost = async (req, res) => {
 //   }
 // };
 
-
 export const getPosts = async (req, res) => {
   try {
     const page = Number(req.query.page) || 1;
@@ -193,24 +192,28 @@ export const getPosts = async (req, res) => {
     }
 
     if (req.query.correctable === 'true') {
+      if (!req.user) {
+        return res.status(401).json({ message: 'Authentication required' });
+      }
+
       const user = await userModel.findById(req.user.id);
-      
+
       if (!user) {
-        return res.status(404).json({ message: "User not found" });
+        return res.status(404).json({ message: 'User not found' });
       }
 
       filter.status = { $in: ['submitted', 'corrected'] };
-      
+
       // 1. Must NOT be the author
       filter['author._id'] = { $ne: new mongoose.Types.ObjectId(req.user.id) };
-      
+
       // 2. Must be in the user's native language
       filter.language = user.native_language;
 
       // 3. Must NOT have been already corrected by this user
       // This targets the 'corrector._id' inside your corrections array
-      filter['corrections.corrector._id'] = { 
-        $ne: new mongoose.Types.ObjectId(req.user.id) 
+      filter['corrections.corrector._id'] = {
+        $ne: new mongoose.Types.ObjectId(req.user.id),
       };
     }
 
@@ -242,11 +245,11 @@ export const getPosts = async (req, res) => {
         word_count: post.word_count,
         reading_time: post.reading_time,
         corrections_count: post.corrections_count,
-        
+
         // --- NEW FIELD ---
         // Mapping the corrections array to a simple array of IDs for the frontend
-        correctors: post.corrections.map(c => c.corrector._id.toString()),
-        
+        correctors: post.corrections.map((c) => c.corrector._id.toString()),
+
         status: post.status,
         created_at: post.created_at,
       })),

--- a/backend/controllers/post.controller.js
+++ b/backend/controllers/post.controller.js
@@ -215,6 +215,8 @@ export const getPosts = async (req, res) => {
       filter['corrections.corrector._id'] = {
         $ne: new mongoose.Types.ObjectId(req.user.id),
       };
+
+      if (req.query.level) filter.fluency_level = req.query.level;
     }
 
     const total = await postModel.countDocuments(filter);

--- a/frontend/src/features/correct/components/CorrectionList.jsx
+++ b/frontend/src/features/correct/components/CorrectionList.jsx
@@ -4,7 +4,7 @@ import { fetchCorrectionQueue } from '../correctionActions';
 import CorrectionCard from './CorrectionCard';
 import { Loader2 } from 'lucide-react';
 
-export default function CorrectionList() {
+export default function CorrectionList({ activeFilters }) {
   const dispatch = useDispatch();
   const { queue, loading, error } = useSelector((state) => state.corrections);
 
@@ -12,12 +12,20 @@ export default function CorrectionList() {
     dispatch(fetchCorrectionQueue());
   }, [dispatch]);
 
+  const filteredQueue = queue.filter((item) => {
+    const matchesLevel =
+      activeFilters.level === 'All' ||
+      item.fluency_level === activeFilters.level;
+
+    return matchesLevel;
+  });
+
   // Debugging the raw data from Redux
   // console.log('Redux Queue State:', queue);
 
   if (loading) {
     return (
-      <div className='flex justify-center py-20'>
+      <div className='flex py-20'>
         <Loader2 className='animate-spin text-[#5D45FD]' size={40} />
       </div>
     );
@@ -33,17 +41,17 @@ export default function CorrectionList() {
 
   return (
     <div className='flex flex-col gap-4 md:gap-6 px-2 md:px-0'>
-      {queue && queue.length > 0 ? (
-        queue.map((item) => (
+      {filteredQueue && filteredQueue.length > 0 ? (
+        filteredQueue.map((item) => (
           <CorrectionCard key={item._id || item.id} item={item} />
         ))
       ) : (
         <div className='bg-white rounded-[32px] p-12 text-center border border-dashed border-gray-200 text-gray-400'>
           <p className='text-lg font-medium text-gray-600 mb-2'>
-            The queue is empty.
+            No reflections need corrections right now.
           </p>
           <p className='text-sm'>
-            The backend returned 0 results for "correctable=true".
+            Check back later for new learner submissions.
           </p>
         </div>
       )}

--- a/frontend/src/features/correct/components/CorrectionList.jsx
+++ b/frontend/src/features/correct/components/CorrectionList.jsx
@@ -1,24 +1,22 @@
-import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { fetchCorrectionQueue } from '../correctionActions';
 import CorrectionCard from './CorrectionCard';
 import { Loader2 } from 'lucide-react';
 
-export default function CorrectionList({ activeFilters }) {
-  const dispatch = useDispatch();
-  const { queue, loading, error } = useSelector((state) => state.corrections);
-
-  useEffect(() => {
-    dispatch(fetchCorrectionQueue());
-  }, [dispatch]);
-
+export default function CorrectionList({
+  queue = [],
+  loading,
+  error,
+  activeFilters,
+}) {
   const filteredQueue = queue.filter((item) => {
     const matchesLevel =
       activeFilters.level === 'All' ||
-      item.fluency_level === activeFilters.level;
+      item.fluency_level?.toLowerCase() === activeFilters.level.toLowerCase();
 
     return matchesLevel;
   });
+
+  console.log('queue:', queue);
+  console.log('activeFilters:', activeFilters);
 
   // Debugging the raw data from Redux
   // console.log('Redux Queue State:', queue);

--- a/frontend/src/features/correct/components/CorrectionList.jsx
+++ b/frontend/src/features/correct/components/CorrectionList.jsx
@@ -1,26 +1,7 @@
 import CorrectionCard from './CorrectionCard';
 import { Loader2 } from 'lucide-react';
 
-export default function CorrectionList({
-  queue = [],
-  loading,
-  error,
-  activeFilters,
-}) {
-  const filteredQueue = queue.filter((item) => {
-    const matchesLevel =
-      activeFilters.level === 'All' ||
-      item.fluency_level?.toLowerCase() === activeFilters.level.toLowerCase();
-
-    return matchesLevel;
-  });
-
-  console.log('queue:', queue);
-  console.log('activeFilters:', activeFilters);
-
-  // Debugging the raw data from Redux
-  // console.log('Redux Queue State:', queue);
-
+export default function CorrectionList({ queue = [], loading, error }) {
   if (loading) {
     return (
       <div className='flex py-20'>
@@ -39,8 +20,8 @@ export default function CorrectionList({
 
   return (
     <div className='flex flex-col gap-4 md:gap-6 px-2 md:px-0'>
-      {filteredQueue && filteredQueue.length > 0 ? (
-        filteredQueue.map((item) => (
+      {queue.length > 0 ? (
+        queue.map((item) => (
           <CorrectionCard key={item._id || item.id} item={item} />
         ))
       ) : (

--- a/frontend/src/features/correct/components/Pagination.jsx
+++ b/frontend/src/features/correct/components/Pagination.jsx
@@ -1,0 +1,39 @@
+import { Button } from '@/components/ui/button';
+
+export default function Pagination({ page, totalPages, setPage }) {
+  if (!totalPages || totalPages <= 1) return null;
+
+  return (
+    <div className='flex justify-center items-center gap-2 mt-6'>
+      <Button
+        variant='outline'
+        disabled={page === 1}
+        onClick={() => setPage(page - 1)}
+      >
+        Previous
+      </Button>
+
+      {Array.from({ length: totalPages }, (_, index) => {
+        const pageNumber = index + 1;
+
+        return (
+          <Button
+            key={pageNumber}
+            variant={page === pageNumber ? 'default' : 'outline'}
+            onClick={() => setPage(pageNumber)}
+          >
+            {pageNumber}
+          </Button>
+        );
+      })}
+
+      <Button
+        variant='outline'
+        disabled={page === totalPages}
+        onClick={() => setPage(page + 1)}
+      >
+        Next
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/features/correct/components/Pagination.jsx
+++ b/frontend/src/features/correct/components/Pagination.jsx
@@ -5,35 +5,24 @@ export default function Pagination({ page, totalPages, setPage }) {
 
   return (
     <div className='flex justify-center items-center gap-2 mt-6'>
-      <Button
-        variant='outline'
-        disabled={page === 1}
-        onClick={() => setPage(page - 1)}
-      >
-        Previous
-      </Button>
-
       {Array.from({ length: totalPages }, (_, index) => {
         const pageNumber = index + 1;
+        const isActive = page === pageNumber;
+        console.log(page, pageNumber, page === pageNumber);
 
         return (
           <Button
             key={pageNumber}
-            variant={page === pageNumber ? 'default' : 'outline'}
+            variant='outline'
+            className={
+              isActive ? 'bg-indigo-100 hover:bg-indigo-200 text-black' : ''
+            }
             onClick={() => setPage(pageNumber)}
           >
             {pageNumber}
           </Button>
         );
       })}
-
-      <Button
-        variant='outline'
-        disabled={page === totalPages}
-        onClick={() => setPage(page + 1)}
-      >
-        Next
-      </Button>
     </div>
   );
 }

--- a/frontend/src/features/correct/correctionActions.js
+++ b/frontend/src/features/correct/correctionActions.js
@@ -20,9 +20,9 @@ export const createCorrection = createAsyncThunk(
 
 export const fetchCorrectionQueue = createAsyncThunk(
   'corrections/fetchCorrectionQueue',
-  async ({ page = 1, limit = 10 } = {}, { rejectWithValue }) => {
+  async ({ page = 1, limit = 10, filters = {} } = {}, { rejectWithValue }) => {
     try {
-      return await getCorrectionQueue(page, limit);
+      return await getCorrectionQueue(page, limit, filters);
     } catch (err) {
       return rejectWithValue(
         err.response?.data?.message || 'Failed to load correction queue.',

--- a/frontend/src/features/correct/correctionActions.js
+++ b/frontend/src/features/correct/correctionActions.js
@@ -1,5 +1,9 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { submitCorrection, getCorrectionQueue, getMyCorrections } from './correctionService';
+import {
+  submitCorrection,
+  getCorrectionQueue,
+  getMyCorrections,
+} from './correctionService';
 
 export const createCorrection = createAsyncThunk(
   'corrections/createCorrection',
@@ -8,26 +12,24 @@ export const createCorrection = createAsyncThunk(
       return await submitCorrection(id, correctionData);
     } catch (err) {
       return rejectWithValue(
-        err.response?.data?.message || 'Failed to submit correction.'
+        err.response?.data?.message || 'Failed to submit correction.',
       );
     }
-  }
+  },
 );
 
 export const fetchCorrectionQueue = createAsyncThunk(
   'corrections/fetchCorrectionQueue',
-  async (_, { rejectWithValue }) => {
+  async ({ page = 1, limit = 10 } = {}, { rejectWithValue }) => {
     try {
-      return await getCorrectionQueue();
+      return await getCorrectionQueue(page, limit);
     } catch (err) {
       return rejectWithValue(
-        err.response?.data?.message || 'Failed to load correction queue.'
+        err.response?.data?.message || 'Failed to load correction queue.',
       );
     }
-  }
+  },
 );
-
-
 
 // export const fetchMyCorrections = createAsyncThunk(
 //   'corrections/fetchMyCorrections',
@@ -42,9 +44,6 @@ export const fetchCorrectionQueue = createAsyncThunk(
 //   }
 // );
 
-
-
-
 export const fetchMyCorrections = createAsyncThunk(
   'corrections/fetchMyCorrections',
   async (type, { rejectWithValue }) => {
@@ -53,8 +52,8 @@ export const fetchMyCorrections = createAsyncThunk(
       return await getMyCorrections(type);
     } catch (err) {
       return rejectWithValue(
-        err.response?.data?.message || 'Failed to load corrections.'
+        err.response?.data?.message || 'Failed to load corrections.',
       );
     }
-  }
+  },
 );

--- a/frontend/src/features/correct/correctionService.js
+++ b/frontend/src/features/correct/correctionService.js
@@ -8,7 +8,7 @@ export const submitCorrection = async (id, correctionData) => {
 export const getCorrectionQueue = async () => {
   // Direct hit to the resource root
   const res = await api.get('/posts?correctable=true');
-  console.log('single post response:', res.data);
+  // console.log('queue res:', res.data);
   return res.data.data;
 };
 

--- a/frontend/src/features/correct/correctionService.js
+++ b/frontend/src/features/correct/correctionService.js
@@ -5,11 +5,14 @@ export const submitCorrection = async (id, correctionData) => {
   return res.data;
 };
 
-export const getCorrectionQueue = async () => {
-  // Direct hit to the resource root
-  const res = await api.get('/posts?correctable=true');
-  // console.log('queue res:', res.data);
-  return res.data.data;
+export const getCorrectionQueue = async (page = 1, limit = 10) => {
+  const res = await api.get(
+    `/posts?correctable=true&page=${page}&limit=${limit}`,
+  );
+
+  console.log('queue res:', res.data);
+
+  return res.data;
 };
 
 // export const getMyCorrections = async () => {

--- a/frontend/src/features/correct/correctionService.js
+++ b/frontend/src/features/correct/correctionService.js
@@ -5,16 +5,16 @@ export const submitCorrection = async (id, correctionData) => {
   return res.data;
 };
 
-export const getCorrectionQueue = async (page = 1, limit = 10) => {
-  const res = await api.get(
-    `/posts?correctable=true&page=${page}&limit=${limit}`,
-  );
+export const getCorrectionQueue = async (page, limit, filters = {}) => {
+  const params = new URLSearchParams({ page, limit, correctable: true });
 
-  console.log('queue res:', res.data);
+  if (filters.level && filters.level !== 'All') {
+    params.append('level', filters.level);
+  }
 
+  const res = await api.get(`/posts?${params}`);
   return res.data;
 };
-
 // export const getMyCorrections = async () => {
 //   const res = await api.get('/corrections/me');
 //   return res.data.data;

--- a/frontend/src/features/correct/correctionSlice.js
+++ b/frontend/src/features/correct/correctionSlice.js
@@ -1,17 +1,24 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { 
-  createCorrection, 
-  fetchCorrectionQueue, 
-  fetchMyCorrections 
+import {
+  createCorrection,
+  fetchCorrectionQueue,
+  fetchMyCorrections,
 } from './correctionActions';
 
 const initialState = {
-  queue: [],           // Posts waiting for correction
-  myCorrections: [],   // User's personal correction history (both made & received)
-  activeTab: 'made',   // Tracks the current view: 'made' or 'received'
+  queue: [], // Posts waiting for correction
+  pagination: {
+    page: 1,
+    limit: 10,
+    total: 0,
+    total_pages: 1,
+  },
+
+  myCorrections: [], // User's personal correction history (both made & received)
+  activeTab: 'made', // Tracks the current view: 'made' or 'received'
   loading: false,
   error: null,
-  
+
   // Submission tracking
   submitting: false,
   submitError: null,
@@ -26,7 +33,7 @@ const correctionSlice = createSlice({
     setActiveTab: (state, action) => {
       state.activeTab = action.payload;
       // Optional: Clear current list so user doesn't see old data while loading new tab
-      state.myCorrections = []; 
+      state.myCorrections = [];
     },
     resetCorrectionStatus: (state) => {
       state.submitting = false;
@@ -36,7 +43,7 @@ const correctionSlice = createSlice({
     clearCorrectionHistory: (state) => {
       state.myCorrections = [];
       state.activeTab = 'made';
-    }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -47,7 +54,9 @@ const correctionSlice = createSlice({
       })
       .addCase(fetchCorrectionQueue.fulfilled, (state, action) => {
         state.loading = false;
-        state.queue = action.payload;
+        state.queue = action.payload.data;
+        state.pagination = action.payload.pagination;
+        console.log('fulfilled payload:', action.payload);
       })
       .addCase(fetchCorrectionQueue.rejected, (state, action) => {
         state.loading = false;
@@ -85,10 +94,7 @@ const correctionSlice = createSlice({
   },
 });
 
-export const { 
-  resetCorrectionStatus, 
-  clearCorrectionHistory, 
-  setActiveTab 
-} = correctionSlice.actions;
+export const { resetCorrectionStatus, clearCorrectionHistory, setActiveTab } =
+  correctionSlice.actions;
 
 export default correctionSlice.reducer;

--- a/frontend/src/features/correct/pages/Correct.jsx
+++ b/frontend/src/features/correct/pages/Correct.jsx
@@ -2,9 +2,9 @@ import { ArrowLeft, Sparkles, Send, Loader2 } from 'lucide-react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchSubmissionById } from '../../submissions/submissionActions'; 
-import { clearSelectedSubmission } from '../../submissions/submissionSlice'; 
-import { createCorrection } from '../correctionActions'; 
+import { fetchSubmissionById } from '../../submissions/submissionActions';
+import { clearSelectedSubmission } from '../../submissions/submissionSlice';
+import { createCorrection } from '../correctionActions';
 import { resetCorrectionStatus } from '../correctionSlice';
 
 export default function Correct() {
@@ -14,13 +14,13 @@ export default function Correct() {
   const location = useLocation();
 
   // 1. Get Submission Details from Redux
-  const { 
-    selectedSubmission, 
-    detailLoading, 
-    detailError 
-  } = useSelector((state) => state.submissions);
+  const { selectedSubmission, detailLoading, detailError } = useSelector(
+    (state) => state.submissions,
+  );
 
-  const { submitting, submitSuccess, submitError } = useSelector((state) => state.corrections);
+  const { submitting, submitSuccess } = useSelector(
+    (state) => state.corrections,
+  );
 
   // 2. Data Logic: Prioritize full Redux data over the 'preview' version from location state
   const submissionData = selectedSubmission?.data || selectedSubmission;
@@ -32,11 +32,11 @@ export default function Correct() {
   // 3. Force fetch if we don't have the 'content' field (even if location state exists)
   useEffect(() => {
     const hasFullContent = location.state?.submission?.content;
-    
+
     if (id && !hasFullContent) {
       dispatch(fetchSubmissionById(id));
     }
-    
+
     return () => dispatch(clearSelectedSubmission());
   }, [id, location.state, dispatch]);
 
@@ -49,37 +49,46 @@ export default function Correct() {
 
   const handleSubmitCorrection = () => {
     if (!id || !correction.trim()) return;
-    dispatch(createCorrection({ id, correctionData: { 
-      corrected_text: correction.trim(), 
-      notes: notes.trim() 
-    }}));
+    dispatch(
+      createCorrection({
+        id,
+        correctionData: {
+          corrected_text: correction.trim(),
+          notes: notes.trim(),
+        },
+      }),
+    );
   };
 
   return (
     <div className='min-h-screen bg-[#F8FAFF] px-4 py-6 md:px-12 md:py-8 font-sans'>
-      <div className='container mx-auto flex justify-between items-center mb-8'>
-        <button onClick={() => navigate('/correct')} className='flex items-center gap-2 text-gray-500 hover:text-[#5D45FD] font-medium text-sm'>
+      <div className='mx-auto flex justify-between items-center mb-8'>
+        <button
+          onClick={() => navigate('/correct')}
+          className='flex gap-2 text-gray-500 hover:text-[#5D45FD] font-medium text-sm'
+        >
           <ArrowLeft size={18} /> Back to Queue
         </button>
-        <div className='flex items-center gap-2 bg-[#E8FFF3] text-[#10B981] px-4 py-2 rounded-full border border-[#D1FAE5]'>
+        <div className='flex gap-2 bg-[#E8FFF3] text-[#10B981] px-4 py-2 rounded-full border border-[#D1FAE5]'>
           <Sparkles size={16} fill='currentColor' />
           <span className='text-xs font-bold uppercase'>Reward: 1 credit</span>
         </div>
       </div>
 
       <div className='container mx-auto grid grid-cols-1 lg:grid-cols-12 gap-8 items-start'>
-        
         {/* Sidebar: Original Submission */}
         <div className='lg:col-span-4 space-y-4'>
-          <h2 className='text-lg font-bold text-[#1A1A1A] px-2'>Original Submission</h2>
-          
+          <h2 className='text-lg font-bold text-[#1A1A1A] px-2'>
+            Original Submission
+          </h2>
+
           <div className='bg-[#EEF2FF] rounded-[32px] p-8 border border-indigo-50 min-h-[250px] flex flex-col'>
             {detailLoading ? (
-              <div className="flex-1 flex items-center justify-center">
-                <Loader2 className="animate-spin text-[#5D45FD]" size={32} />
+              <div className='flex-1 flex items-center justify-center'>
+                <Loader2 className='animate-spin text-[#5D45FD]' size={32} />
               </div>
             ) : detailError ? (
-              <div className="text-red-500 text-sm p-4">{detailError}</div>
+              <div className='text-red-500 text-sm p-4'>{detailError}</div>
             ) : displayData ? (
               <>
                 <div className='flex gap-2 mb-4'>
@@ -90,24 +99,35 @@ export default function Correct() {
                     {displayData.fluency_level}
                   </span>
                 </div>
-                
+
                 {/* FIX: Check content first, then fallback to preview */}
                 <p className='text-[#1A1A1A] leading-relaxed text-[15px] italic'>
-                  "{displayData.content || displayData.preview || "Loading full text..."}"
+                  "
+                  {displayData.content ||
+                    displayData.preview ||
+                    'Loading full text...'}
+                  "
                 </p>
 
-                <div className="mt-auto pt-6 border-t border-indigo-100/50 flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-full bg-white flex items-center justify-center text-[#5D45FD] font-bold text-xs shadow-sm border border-indigo-50">
-                    {displayData.author?.username?.charAt(0).toUpperCase() || '?'}
+                <div className='mt-auto pt-6 border-t border-indigo-100/50 flex items-center gap-3'>
+                  <div className='w-8 h-8 rounded-full bg-white flex items-center justify-center text-[#5D45FD] font-bold text-xs shadow-sm border border-indigo-50'>
+                    {displayData.author?.username?.charAt(0).toUpperCase() ||
+                      '?'}
                   </div>
                   <div>
-                    <p className="text-[10px] text-indigo-400 font-bold uppercase tracking-wide">Author</p>
-                    <p className="text-sm font-bold text-indigo-900">{displayData.author?.username}</p>
+                    <p className='text-[10px] text-indigo-400 font-bold uppercase tracking-wide'>
+                      Author
+                    </p>
+                    <p className='text-sm font-bold text-indigo-900'>
+                      {displayData.author?.username}
+                    </p>
                   </div>
                 </div>
               </>
             ) : (
-              <div className="text-gray-400 text-sm">No submission data available.</div>
+              <div className='text-gray-400 text-sm'>
+                No submission data available.
+              </div>
             )}
           </div>
         </div>
@@ -115,7 +135,9 @@ export default function Correct() {
         {/* Right Form: Correction Input */}
         <div className='lg:col-span-8 space-y-6'>
           <section className='space-y-3'>
-            <h2 className='text-lg font-bold text-[#1A1A1A] px-2'>Your Correction</h2>
+            <h2 className='text-lg font-bold text-[#1A1A1A] px-2'>
+              Your Correction
+            </h2>
             <textarea
               placeholder='Correct the grammar and flow...'
               value={correction}
@@ -126,7 +148,9 @@ export default function Correct() {
           </section>
 
           <section className='space-y-3'>
-            <h2 className='text-lg font-bold text-[#1A1A1A] px-2 text-sm'>Notes (optional)</h2>
+            <h2 className='text-lg font-bold text-[#1A1A1A] px-2 text-sm'>
+              Notes (optional)
+            </h2>
             <textarea
               placeholder='Explain your changes...'
               value={notes}
@@ -141,7 +165,13 @@ export default function Correct() {
             disabled={submitting || !correction.trim()}
             className='w-full py-4 bg-[#5D45FD] text-white font-bold rounded-full hover:bg-[#4a36cc] flex items-center justify-center gap-2 transition-all disabled:bg-gray-300'
           >
-            {submitting ? <Loader2 className="animate-spin" size={18} /> : <>Submit Correction <Send size={18} /></>}
+            {submitting ? (
+              <Loader2 className='animate-spin' size={18} />
+            ) : (
+              <>
+                Submit Correction <Send size={18} />
+              </>
+            )}
           </button>
         </div>
       </div>

--- a/frontend/src/features/correct/pages/CorrectionQueue.jsx
+++ b/frontend/src/features/correct/pages/CorrectionQueue.jsx
@@ -43,11 +43,7 @@ export default function CorrectionQueue() {
           loading={loading}
           error={error}
         />
-        <Pagination
-          pages={pagination?.page}
-          totalPages={totalPages}
-          setPage={setPage}
-        />
+        <Pagination page={page} totalPages={totalPages} setPage={setPage} />
       </div>
     </div>
   );

--- a/frontend/src/features/correct/pages/CorrectionQueue.jsx
+++ b/frontend/src/features/correct/pages/CorrectionQueue.jsx
@@ -12,7 +12,7 @@ export default function CorrectionQueue() {
   });
 
   return (
-    <div className='min-h-screen flex flex-col justify-center  bg-[#F8FAFF] py-6 pb-24 md:px-28 md:py-8'>
+    <div className='min-h-screen flex flex-col  bg-[#F8FAFF] py-6 pb-24 md:px-28 md:py-8'>
       {/* <aside className='hidden lg:block lg:col-span-4'>
           <FluentLanguagesCard />
         </aside> */}

--- a/frontend/src/features/correct/pages/CorrectionQueue.jsx
+++ b/frontend/src/features/correct/pages/CorrectionQueue.jsx
@@ -1,9 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchCorrectionQueue } from '../correctionActions';
 
 import FilterHeader from '../components/FilterHeader';
-import FluentLanguagesCard from '@/features/correct/components/FluentLanguagesCard';
 import CorrectionList from '../components/CorrectionList';
 import Pagination from '../components/Pagination';
 
@@ -23,8 +22,13 @@ export default function CorrectionQueue() {
   const totalPages = pagination?.total_pages || 1;
 
   useEffect(() => {
-    dispatch(fetchCorrectionQueue({ page }));
-  }, [dispatch, page]);
+    dispatch(fetchCorrectionQueue({ page, filters }));
+  }, [dispatch, page, filters.language, filters.level]);
+
+  const handleSetFilters = useCallback((updater) => {
+    setFilters(updater);
+    setPage(1);
+  }, []);
 
   return (
     <div className='min-h-screen flex flex-col  bg-[#F8FAFF] py-6 pb-24 md:px-28 md:py-8'>
@@ -33,16 +37,11 @@ export default function CorrectionQueue() {
         </aside> */}
 
       {/* 2. Pass the state and the setter function as props */}
-      <FilterHeader filters={filters} setFilters={setFilters} />
+      <FilterHeader filters={filters} setFilters={handleSetFilters} />
 
       <div className='px-4 mt-4'>
         {/* 3. Pass the active filters to the feed so it can filter the cards */}
-        <CorrectionList
-          activeFilters={filters}
-          queue={queue}
-          loading={loading}
-          error={error}
-        />
+        <CorrectionList queue={queue} loading={loading} error={error} />
         <Pagination page={page} totalPages={totalPages} setPage={setPage} />
       </div>
     </div>

--- a/frontend/src/features/correct/pages/CorrectionQueue.jsx
+++ b/frontend/src/features/correct/pages/CorrectionQueue.jsx
@@ -1,8 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchCorrectionQueue } from '../correctionActions';
 
 import FilterHeader from '../components/FilterHeader';
 import FluentLanguagesCard from '@/features/correct/components/FluentLanguagesCard';
 import CorrectionList from '../components/CorrectionList';
+import Pagination from '../components/Pagination';
 
 export default function CorrectionQueue() {
   // 1. Initialize the filter state here
@@ -10,6 +13,18 @@ export default function CorrectionQueue() {
     language: 'All',
     level: 'All',
   });
+
+  const [page, setPage] = useState(1);
+
+  const dispatch = useDispatch();
+  const { queue, loading, error, pagination } = useSelector(
+    (state) => state.corrections,
+  );
+  const totalPages = pagination?.total_pages || 1;
+
+  useEffect(() => {
+    dispatch(fetchCorrectionQueue({ page }));
+  }, [dispatch, page]);
 
   return (
     <div className='min-h-screen flex flex-col  bg-[#F8FAFF] py-6 pb-24 md:px-28 md:py-8'>
@@ -22,7 +37,17 @@ export default function CorrectionQueue() {
 
       <div className='px-4 mt-4'>
         {/* 3. Pass the active filters to the feed so it can filter the cards */}
-        <CorrectionList activeFilters={filters} />
+        <CorrectionList
+          activeFilters={filters}
+          queue={queue}
+          loading={loading}
+          error={error}
+        />
+        <Pagination
+          pages={pagination?.page}
+          totalPages={totalPages}
+          setPage={setPage}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Refactored Corrections queue to support backend filtering and pagination

Changes

postController.js
- Added `level` query param support, mapped to `fluency_level` in the Mongoose filter
- Filter is applied before `countDocuments` so `total_pages` reflects the filtered result

correctionService.js
- Forwards `level` as a query param to the API when a filter is active

correctionActions.js
- `fetchCorrectionQueue` thunk now accepts and passes `filters` down to the service

CorrectionQueue.jsx
- Dispatches `filters` with every fetch
- Uses `useMemo` on the filters object to stabilize the `useEffect` dependency and avoid infinite refetch loops

CorrectionList.jsx
- Removed `activeFilters` prop and all frontend filter logic
- Renders `queue` directly since the backend now returns pre-filtered data
