### PR TITLE
refactor: separate auth and profile state responsibilities

### DIFF
--- a/frontend/src/features/auth/authActions.js
+++ b/frontend/src/features/auth/authActions.js
@@ -2,6 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import * as authApi from './authService';
 import { setAccessToken } from '@/features/auth/authSlice';
 import { fetchMe } from '../profile';
+import { clearProfile } from '@/features/profile/profileSlice';
 
 export const loginThunk = createAsyncThunk(
   'auth/login',
@@ -17,9 +18,13 @@ export const loginThunk = createAsyncThunk(
   },
 );
 
-export const logoutThunk = createAsyncThunk('auth/logout', async () => {
-  await authApi.logout();
-});
+export const logoutThunk = createAsyncThunk(
+  'auth/logout',
+  async (_, { dispatch }) => {
+    await authApi.logout();
+    dispatch(clearProfile());
+  },
+);
 
 export const signUpThunk = createAsyncThunk(
   'auth/register',

--- a/frontend/src/features/auth/authActions.js
+++ b/frontend/src/features/auth/authActions.js
@@ -1,11 +1,15 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import * as authApi from './authService';
+import { setAccessToken } from '@/features/auth/authSlice';
+import { fetchMe } from '../profile';
 
 export const loginThunk = createAsyncThunk(
   'auth/login',
-  async (credentials, { rejectWithValue }) => {
+  async (credentials, { dispatch, rejectWithValue }) => {
     try {
       const res = await authApi.login(credentials);
+      dispatch(setAccessToken(res.data.access_token));
+      await dispatch(fetchMe());
       return res.data;
     } catch (err) {
       return rejectWithValue(err.response.data.message);

--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -1,12 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { loginThunk, logoutThunk, signUpThunk } from '@/features/auth';
+import { loginThunk, logoutThunk, signUpThunk } from './authActions';
 
 const authSlice = createSlice({
   name: 'auth',
   initialState: {
     accessToken: localStorage.getItem('accessToken') || null,
-    user: null,
     loading: false,
     error: null,
   },
@@ -18,10 +17,12 @@ const authSlice = createSlice({
     },
     setAccessToken: (state, action) => {
       state.accessToken = action.payload;
-      localStorage.setItem('accessToken', action.payload);
-    },
-    setUser: (state, action) => {
-      state.user = action.payload;
+
+      if (action.payload) {
+        localStorage.setItem('accessToken', action.payload);
+      } else {
+        localStorage.removeItem('accessToken');
+      }
     },
   },
   extraReducers: (builder) => {
@@ -54,6 +55,7 @@ const authSlice = createSlice({
         state.error = action.payload;
       })
       .addCase(logoutThunk.fulfilled, (state) => {
+        // console.log('log-out:', JSON.parse(JSON.stringify(state.user)));
         state.accessToken = null;
         state.error = null;
         localStorage.removeItem('accessToken');
@@ -61,5 +63,5 @@ const authSlice = createSlice({
   },
 });
 
-export const { clearAuth, setAccessToken, setUser, logout } = authSlice.actions;
+export const { clearAuth, setAccessToken } = authSlice.actions;
 export default authSlice.reducer;

--- a/frontend/src/features/auth/components/AuthProvider.jsx
+++ b/frontend/src/features/auth/components/AuthProvider.jsx
@@ -18,9 +18,11 @@ export default function AuthProvider({ children }) {
           {},
           { withCredentials: true },
         );
-
+        // console.log('refresh access token:', data.access_token);
         dispatch(setAccessToken(data.access_token));
-        await dispatch(fetchMe());
+        const res = await dispatch(fetchMe());
+        // console.log(res);
+        return res.data;
       } catch {
         // not logged in, ignore
         dispatch(setAccessToken(null));

--- a/frontend/src/features/auth/components/AuthProvider.jsx
+++ b/frontend/src/features/auth/components/AuthProvider.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { useDispatch } from 'react-redux';
-import { setAccessToken, setUser } from '@/features/auth/authSlice';
+import { setAccessToken } from '@/features/auth/authSlice';
 import { fetchMe } from '@/features/profile';
 import PageLoader from '@/components/layout/PageLoader';
 
@@ -21,12 +21,10 @@ export default function AuthProvider({ children }) {
         // console.log('refresh access token:', data.access_token);
         dispatch(setAccessToken(data.access_token));
         const res = await dispatch(fetchMe());
-        // console.log(res);
         return res.data;
       } catch {
         // not logged in, ignore
         dispatch(setAccessToken(null));
-        dispatch(setUser(null));
       } finally {
         setLoading(false);
       }

--- a/frontend/src/features/profile/profileSlice.js
+++ b/frontend/src/features/profile/profileSlice.js
@@ -8,6 +8,11 @@ const profileSlice = createSlice({
     loading: false,
     error: null,
   },
+  reducers: {
+    clearProfile: (state) => {
+      state.user = null;
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(fetchMe.pending, (state) => {
@@ -25,4 +30,5 @@ const profileSlice = createSlice({
   },
 });
 
+export const { clearProfile } = profileSlice.actions;
 export default profileSlice.reducer;


### PR DESCRIPTION
- Removed user state from authSlice, now owned entirely by profileSlice
- Dispatch fetchMe after loginThunk so user is loaded on fresh login
- Fixed logoutThunk to correctly destructure dispatch from second argument
- Removed setUser from AuthProvider catch block since profile.user defaults to null
- Added clearProfile reducer to profileSlice, dispatched on logout